### PR TITLE
set RPC port to default

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     development: {
       host: "localhost",
-      port: 8546,
+      port: 8545,
       network_id: "*"		// Match any network id
     },
    	live: {


### PR DESCRIPTION
This is the default and more people dev with testrpc which defaults to this port.

If we want to have different behavior based upon network we should include that in the truffle migrations folder.